### PR TITLE
Update Find-PSServiceAccounts

### DIFF
--- a/Find-PSServiceAccounts
+++ b/Find-PSServiceAccounts
@@ -176,12 +176,11 @@ ForEach ($AllServiceAccountsItem in $AllServiceAccounts)
 
 $AllServiceAccountsReport = $AllServiceAccountsReport | Select-Object Domain,UserID,PasswordLastSet,LastLogon,Description,SPNServers,SPNTypes,ServicePrincipalNames
 
-If ($DumpSPNs -eq $True)
+If ($DumpSPNs)
     {
         [array]$AllServiceAccountsSPNs = $AllServiceAccountsSPNs | sort-object | Get-Unique
-        return $AllServiceAccountsSPNs
         
-        IF ($GetTGS)
+        If ($GetTGS)
             {
                 ForEach ($AllServiceAccountsSPNsItem in $AllServiceAccountsSPNs)
                     {
@@ -189,6 +188,8 @@ If ($DumpSPNs -eq $True)
                         New-Object System.IdentityModel.Tokens.KerberosRequestorSecurityToken -ArgumentList "$AllServiceAccountsSPNsItem"
                     }
             }
+            
+        return $AllServiceAccountsSPNs
     }
 
 ELSE

--- a/Find-PSServiceAccounts
+++ b/Find-PSServiceAccounts
@@ -69,11 +69,11 @@ IF ($Scope -eq "Domain")
         IF (!($DomainName))
             { 
                 $ADDomainInfo = [System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain()
-                $ADDomainName = $ADDomainInfo.Name
+                $DomainName = $ADDomainInfo.Name
             }
-        $ADDomainDN = "DC=" + $ADDomainName -Replace("\.",',DC=')
+        $ADDomainDN = "DC=" + $DomainName -Replace("\.",',DC=')
         $ADDomainLDAPDN = 'LDAP://' + $ADDomainDN
-        Write-Output "Discovering service account SPNs in the AD Domain $ADDomainName "
+        Write-Output "Discovering service account SPNs in the AD Domain $DomainName "
     }
 
 IF ( ($Scope -eq "Forest") -AND (!($DomainName)) )


### PR DESCRIPTION
The switch -domainname "xyz.xxx.local" returned an ADSI error, because the $ADDomainName variable was not set, giving wrong values for $ADDomainDN and $ADDomainLDAPDN.
